### PR TITLE
Actualizo links a Learn Git Branching en argento

### DIFF
--- a/docs/.vitepress/configs/sidebar.ts
+++ b/docs/.vitepress/configs/sidebar.ts
@@ -90,7 +90,7 @@ export const sidebar: DefaultTheme.Sidebar = [
       },
       {
         text: 'Learn Git Branching',
-        link: 'https://learngitbranching.js.org/'
+        link: 'https://learngitbranching.js.org/?locale=es_AR'
       },
     ],
   },

--- a/docs/guias/index.md
+++ b/docs/guias/index.md
@@ -13,7 +13,7 @@ página.
 - [Git para el Trabajo Práctico](/guias/consola/git)
 - [Rutas Relativas y Absolutas](/guias/consola/rutas)
 - [Mario Bash ↗️](https://faq.utnso.com.ar/mariobash)
-- [Learn Git Branching (en inglés) ↗️](https://learngitbranching.js.org/)
+- [Learn Git Branching ↗️](https://learngitbranching.js.org/?locale=es_AR)
 
 ### Programación en C
 


### PR DESCRIPTION
No sé cuán desactualizada haya quedado, pero hay una traducción al español argentino de Learn Git Branching - se me ocurre que es mejor que linkear a la versión en inglés.