### PR TITLE
Referencias a Eclipse y mejoras varias

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitepress';
 import { navbar } from './configs/navbar';
 import { sidebar } from './configs/sidebar';
 import { socialLinks } from './configs/socialLinks';
+import { repository } from '../../package.json';
 
 export default defineConfig({
   lang: 'es-AR',
@@ -24,7 +25,7 @@ export default defineConfig({
       copyright: 'Universidad Tecnológica Nacional | Facultad Regional Buenos Aires',
     },
     editLink: {
-      pattern: 'https://github.com/sisoputnfrba/docs/edit/main/docs/:path',
+      pattern: `${repository}/edit/main/docs/:path`,
       text: 'Editar esta página en GitHub',
     },
     lastUpdatedText: 'Última actualización',
@@ -38,8 +39,7 @@ export default defineConfig({
     search: {
       provider: 'local',
       options: {
-        disableDetailedView: false,
-        disableQueryPersistence: false,
+        detailedView: true,
         translations: {
           button: {
             buttonText: 'Buscar',

--- a/docs/guias/consola/rutas.md
+++ b/docs/guias/consola/rutas.md
@@ -122,6 +122,13 @@ carpeta `.vscode` de nuestro proyecto, vamos a encontrar un archivo llamado
 "hacerle `cd`". En este caso, siempre va a ser la carpeta en donde se encuentra
 nuestro proyecto.
 
+::: tip
+
+Para más información sobre las variables de Visual Studio Code, pueden visitar
+nuestra [guía de configuración de Visual Studio Code](/guias/herramientas/code).
+
+:::
+
 Entonces, si nosotros queremos ejecutar nuestro programa desde la consola de la
 misma forma que lo hace Visual Studio Code, vamos a tener que hacerlo de la
 siguiente manera:
@@ -131,12 +138,42 @@ cd mi-proyecto
 ./bin/mi-proyecto
 ```
 
+## Eclipse
+
+Trabajando con Eclipse, si vamos a las Run
+Configurations (`Run` > `Run configurations...`) y seleccionamos la de algún
+proyecto que ya hayamos ejecutado, vamos a encontrar que la pestaña de
+"Arguments" es algo así:
+
+![eclipse-run-config-arguments](/img/guias/consola/eclipse-run-config-arguments.png)
+
+¡Ahí está! Abajo de todo dice que el working directory de nuestro proceso va a
+ser `${workspace_loc:NUESTRO_PROYECTO}`, que es la forma horrenda que tiene
+eclipse para decir "el directorio raíz del proyecto". De hecho, si miramos la
+pestaña "Main" de las `Run Configurations`, podemos observar algo raro arriba de
+todo:
+
+![eclipse-run-config-main](/img/guias/consola/eclipse-run-config-main.png)
+
+Nuestra aplicación no es coercion (el nombre del proyecto al que le saqué la
+captura), si no Debug/coercion. Ese es el comando que eclipse "va a ejecutar en
+la consola". Digamos, eclipse va a hacer una especie de `cd` al directorio que
+marca como "Working directory", y desde ahí va a ejecutar lo que diga en el
+campo `C/C++ Application`:
+
+```bash
+cd coercion
+./Debug/coercion
+```
+
+Entonces, como nosotros desde la consola solemos entrar a Debug en lugar de
+ejecutar desde el directorio raíz del proyecto, ahí es donde aparecen las
+diferencias con las rutas relativas.
+
 ::: tip
 
-En realidad, lo que hace Visual Studio Code es ejecutar el programa utilizando
-`gdb` para poder hacer debugging; y, como pueden ver en el campo `program`,
-utiliza una ruta absoluta para llegar al binario. Pero, a fines prácticos, el
-resultado es el mismo.
+Si importaste el proyecto siguiendo la
+[guía de Eclipse](/guias/herramientas/eclipse), probablemente la carpeta se
+llame `bin` en lugar de `Debug`.
 
 :::
-

--- a/docs/guias/herramientas/code.md
+++ b/docs/guias/herramientas/code.md
@@ -43,6 +43,14 @@ El mismo cuenta con la siguiente configuración:
    permite que el editor nos muestre solamente los errores que arroja el
    compilador y no nos distraiga con otros que no lo son.
 
+::: warning IMPORTANTE
+
+En el caso del TP0 y el TP (o siempre que tengamos abiertas varias carpetas en
+un mismo workspace), esta configuración se encuentra en el archivo con formato
+`.code-workspace` ubicado en la raíz del repositorio bajo la clave `settings`.
+
+:::
+
 ## Configuración de compilación
 
 El segundo archivo del que vamos a hablar es el `tasks.json`. En él vamos a

--- a/docs/guias/herramientas/eclipse.md
+++ b/docs/guias/herramientas/eclipse.md
@@ -30,8 +30,8 @@ obj/
 !.vscode/tasks.json
 ```
 
-La desventaja de esto es que cada alumno deberá configurar su proyecto de forma
-manual siguiendo los pasos que se detallan a continuación, pero una vez
+La desventaja de esto es que **cada alumno** deberá configurar su proyecto de
+forma manual siguiendo los pasos que se detallan a continuación, pero una vez
 configurado no deberían volver a tener que hacerlo.
 
 

--- a/docs/guias/programacion/main.md
+++ b/docs/guias/programacion/main.md
@@ -65,7 +65,7 @@ Esto incluso lo podemos mejorar controlando que la cantidad de parámetros sea l
 indicada manejando `argc`:
 
 ```c{2-5}
-int main(int argc, char** argv) {
+int main(int argc, char** argv) {  // [!code focus]
     if (argc < 2) { // [!code focus]
         fprintf(stderr, "Uso: %s <ruta_archivo_configuracion>\n", argv[0]); // [!code focus]
         return EXIT_FAILURE; // [!code focus]
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
     t_config* config = crear_config(argv[1]); // [!code focus]
 
     //resto del TP0 de después
-}
+} // [!code focus]
 ```
 
 ¡Eso es todo! Bueno, casi todo... ¿Cómo podemos lograr esto desde el editor?
@@ -134,6 +134,27 @@ array separados por comas:
 
 :::
 
+
+## Pasar argumentos desde Eclipse
+
+Vamos a entrar a las `Run Configurations...`:
+
+![eclipse-01](/img/guias/programacion/main/eclipse-01.png)
+
+Y en la configuración del proyecto nos moveremos a la pestaña `Arguments`, en
+donde vamos a poner nuestros argumentos separados por espacios:
+
+![eclipse-02](/img/guias/programacion/main/eclipse-02.png)
+
+En caso de usar una [ruta relativa](/guias/consola/rutas), es muy importante
+partir desde el `Working directory` que está configurado ahí más abajo.
+
+Por ejemplo, la variable `${workspace_loc:NOMBRE_DEL_PROYECTO}` apunta hacia la
+carpeta en donde se encuentra el proyecto Eclipse.
+
+
+<br><br>
+
 [^1]: [Guía de Rutas relativas y absolutas](/guias/consola/rutas)
 
-[^2]: [Documentación de las variables de Visual Studio Code (en inglés)](https://code.visualstudio.com/docs/editor/variables-reference)
+[^2]: [Guía de configuraciones de Visual Studio Code](/guias/herramientas/code)

--- a/docs/primeros-pasos/tp0.md
+++ b/docs/primeros-pasos/tp0.md
@@ -1,6 +1,6 @@
 # Trabajo Práctico 0
 
-> Versión 2.4.0
+> Versión 2.4.1
 
 El TP0 es una práctica inicial para empezar a familiarizarse con algunas de las
 herramientas necesarias para el trabajo práctico cuatrimestral como es la

--- a/docs/primeros-pasos/tp0.md
+++ b/docs/primeros-pasos/tp0.md
@@ -71,6 +71,17 @@ Una vez abierto el workspace, vamos a ver que tenemos dos módulos: `client` y
 
 ![vscode-file-explorer](/img/primeros-pasos/tp0/vscode-file-explorer.png){data-zoomable}
 
+
+::: tip
+
+Si venís de algún cuatrimeste anterior y preferís usar Eclipse, podés seguir la
+[guía de Eclipse](/guias/herramientas/eclipse).
+
+Tené en cuenta que esta etapa va a resultar bastante más laboriosa que en Visual
+Studio Code, ya que la configuración debe hacerse manualmente desde cero.
+
+:::
+
 ## Etapa 2: Comandos básicos
 
 El objetivo de esta etapa es aprender un par de funcionalidades que utilizaremos
@@ -128,8 +139,8 @@ corramos el programa y evaluemos los resultados.
 
 ::: warning IMPORTANTE
 
-Para todas las funciones de biblioteca que uses, recuerden chequear los valores
-de retorno de las mismas para poder manejar los casos de error.
+Para todas las funciones de biblioteca que uses, recordá chequear los **valores
+de retorno** de las mismas para poder manejar los casos de error.
 
 En este caso, si llegamos a tener algún error al crear el config vamos a querer
 terminar con la ejecución:
@@ -168,7 +179,7 @@ include.
 
 Recuerden que `readline()` no te libera la memoria que devuelve, por lo que es
 necesario liberarla usando
-[`free(1)`](https://man7.org/linux/man-pages/man1/free.1.html).
+[`free()`](https://man7.org/linux/man-pages/man1/free.1.html).
 
 :::
 
@@ -393,15 +404,10 @@ espacio:
 
 ![vm-clone](/img/primeros-pasos/tp0/vm-clone.png){data-zoomable}
 
-Una vez hecho esto, vamos a consultar la IP de la VM
-del `server` y agregarla al archivo de configuración del `client` para que se
-puedan comunicar entre sí con el comando
-[`ifconfig`](/guias/consola/bash.html#ifconfig).
+### Resolver conflictos de red
 
-::: danger AVISO
-
-Si por algún motivo encuentran que su router les asigna la misma IP a todas las
-VMs clonadas, ejecuten las siguientes 3 líneas:
+Por último, vamos a iniciar sesión en una de las VMs y ejecutar las siguientes 3
+líneas:
 
 ```sh
 sudo rm -f /etc/machine-id
@@ -409,12 +415,29 @@ sudo dbus-uuidgen --ensure=/etc/machine-id
 sudo reboot
 ```
 
-Luego de reiniciar, ejecuten `ifconfig` para
-corroborar que efectivamente las IPs hayan
-cambiado.
+Esto lo que hace es generar un nuevo archivo `/etc/machine-id`, en el cual se
+guarda un identificador que permite al router asignarle la misma IP a una
+máquina cada vez que ésta se conecta a la red.
 
-Pueden ver una explicación más detallada en el siguiente
-[post](https://unix.stackexchange.com/a/419322).
+Al nosotros haber clonado la misma VM, ambas tienen el mismo `machine-id`, por
+lo que el router podría terminar asignándoles la misma IP a ambas VMs, lo cual
+generaría conflictos a la hora de conectarlas en red.
+
+Luego de reiniciar, ejecuten
+[`ifconfig`](/guias/consola/bash#ifconfig) para corroborar que efectivamente las
+IPs de todas las VMs son distintas.
+
+### Configurar los módulos
+
+Ahora sí, vamos a agregar la IP de la VM del `server` al archivo de
+configuración del `client` para que se puedan comunicar entre sí. Para esto
+pueden utilizar el editor de texto `nano`.
+
+::: tip
+
+En la [guía de Bash](/guias/consola/bash) tenemos una sección dedicada a
+[`nano`](/guias/consola/bash#nano) con un mini ejemplo, por si necesitan ayuda
+sobre cómo usarlo.
 
 :::
 


### PR DESCRIPTION
- Volví a agregar secciones que estaban escritas en Eclipse y había cambiado a VSCode en vez de conservar ambas
- Agrego un link desde el TP0 a la guía de Eclipse por si lo quieren importar ahí
- Agrego un warning en la guía de Code que me había olvidado aclarar
- Mejoro la sección del TP0 que explica cómo resolver los conflictos de red y editar las configs.