### PR TITLE
Fix code blocks rendering

### DIFF
--- a/docs/guias/herramientas/cspec.md
+++ b/docs/guias/herramientas/cspec.md
@@ -139,7 +139,7 @@ archivo que contiene la función `main`, que por defecto es `src/main.c`:
 
 ::: code-group
 
-```make [settings.mk]
+```conf [settings.mk]
 # Source files (*.c) to be excluded from tests compilation
 TEST_EXCLUDE= // [!code --]
 TEST_EXCLUDE=src/main.c // [!code ++]

--- a/docs/primeros-pasos/primer-proyecto-c.md
+++ b/docs/primeros-pasos/primer-proyecto-c.md
@@ -167,7 +167,7 @@ errores: `-Werror`
 Podemos agregarlo fácilmente al final de las variables `CDEBUG` y `CRELEASE` del
 archivo `settings.mk`:
 
-```makefile
+```conf
 # Compiler flags
 CDEBUG=-g -Wall -DDEBUG -fdiagnostics-color=always // [!code --]
 CDEBUG=-g -Wall -DDEBUG -fdiagnostics-color=always -Werror // [!code ++]


### PR DESCRIPTION
No sé por qué pero en dev y en mi build local se renderizan bien los diffs, pero en prod particularmente los makefiles se muestran así:

<img width="718" height="182" alt="image" src="https://github.com/user-attachments/assets/f19f4608-c01c-4cd7-8e46-fcc27807f0b0" />
